### PR TITLE
fix: git clone後にGDCubismが動作しない問題を修正

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,4 +1,5 @@
-.godot/
+.godot/*
+!.godot/extension_list.cfg
 /bin/
 .mono/
 *.uid

--- a/frontend/.godot/extension_list.cfg
+++ b/frontend/.godot/extension_list.cfg
@@ -1,0 +1,1 @@
+res://addons/gd_cubism/gd_cubism.gdextension


### PR DESCRIPTION
## Summary

- `git clone` 直後に Godot を起動すると `Cannot get class 'GDCubismUserModel'` エラーが発生する問題を修正
- 原因: `.godot/extension_list.cfg` が gitignore で除外されており、Godot が GDExtension を認識できなかった
- `frontend/.gitignore` を `.godot/*` + `!.godot/extension_list.cfg` のパターンに変更し、このファイルのみgit管理対象に

## Test plan

- [ ] `git clone` 後に `scripts_local/start-frontend.ps1` を実行してGodot起動
- [ ] Live2Dキャラクターが正常にロードされること
- [ ] `[CSM][I]Live2D Cubism Core version` がGodotのOutputに表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)