### PR TITLE
feat: sessionテーブルにemotion/role列を追加 (issue #4)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# デフォルト: テキストファイルは自動判定
+* text=auto
+
+# マイグレーションSQLはLF固定 (Linux/Docker環境で実行されるため)
+backend/migrations/*.sql text eol=lf
+
+# シェルスクリプトはLF固定
+*.sh text eol=lf
+
+# PowerShellスクリプトはCRLF固定 (Windows用)
+*.ps1 text eol=crlf

--- a/scripts_local/start-backend.ps1
+++ b/scripts_local/start-backend.ps1
@@ -1,15 +1,24 @@
 ﻿# nekobox バックエンドサーバ起動スクリプト (ローカル開発用)
 
+param(
+    [switch]$UseLocalEnvvar
+)
+
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $ProjectRoot = Split-Path -Parent $ScriptDir
 
-# 環境変数設定
-$env:NEKOBOX_DB_PATH       = "$ProjectRoot\backend"
-$env:NEKOBOX_LMSTUDIO_HOST = "localhost"
-$env:NEKOBOX_LMSTUDIO_PORT = "1234"
-$env:NEKOBOX_CFG_PATH      = "$ProjectRoot\config"
-$env:NEKOBOX_BIND_HOST     = "127.0.0.1"
-$env:RUST_LOG              = "info"
+# 環境変数設定 (-UseLocalEnvvar 指定時のみスクリプト内の値を使用)
+if ($UseLocalEnvvar) {
+    $env:NEKOBOX_DB_PATH       = "$ProjectRoot\backend"
+    $env:NEKOBOX_LMSTUDIO_HOST = "localhost"
+    $env:NEKOBOX_LMSTUDIO_PORT = "1234"
+    $env:NEKOBOX_CFG_PATH      = "$ProjectRoot\config"
+    $env:NEKOBOX_BIND_HOST     = "127.0.0.1"
+    $env:RUST_LOG              = "info"
+    Write-Host "[nekobox] スクリプト内の環境変数を使用しますまる" -ForegroundColor Yellow
+} else {
+    Write-Host "[nekobox] OS/シェルの環境変数を使用しますまる" -ForegroundColor Yellow
+}
 
 Write-Host "[nekobox] バックエンドサーバを起動しますまる..." -ForegroundColor Cyan
 Write-Host "  DB Path     : $env:NEKOBOX_DB_PATH"


### PR DESCRIPTION
## Summary

- `session` テーブルに `emotion` (VARCHAR, nullable) と `role` (VARCHAR, NOT NULL DEFAULT 'user') 列を追加
- マイグレーション `0003_add_emotion_role.sql` で既存データのバックフィルも実施
- Windows環境での `core.autocrlf=true` によるSQLxマイグレーションチェックサム不一致を修正
  - `.gitattributes` を追加し `backend/migrations/*.sql` を `eol=lf` 固定に設定
- `scripts_local/start-backend.ps1` に `-UseLocalEnvvar` スイッチを追加

## Test plan

- [ ] `cargo run` でマイグレーションエラーが発生しないことを確認
- [ ] `session` テーブルに `emotion` / `role` 列が存在することをSQLiteクライアントで確認
- [ ] `-UseLocalEnvvar` なしで `start-backend.ps1` を起動しOSの環境変数が使われることを確認
- [ ] `-UseLocalEnvvar` ありで `start-backend.ps1` を起動しスクリプト内の環境変数が使われることを確認

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)