### PR TITLE
feat: MCPサポート準備 - uv tool listによるツールリスト取得 (#14)

### DIFF
--- a/backend/src/api/lm_studio.rs
+++ b/backend/src/api/lm_studio.rs
@@ -60,7 +60,7 @@ pub struct HttpLmStudioClient {
 }
 
 impl HttpLmStudioClient {
-    #[must_use] 
+    #[must_use]
     pub fn new(base_url: String) -> Self {
         Self {
             client: reqwest::Client::new(),

--- a/backend/src/api/routes/msg.rs
+++ b/backend/src/api/routes/msg.rs
@@ -256,6 +256,7 @@ mod tests {
             db: Arc::new(db),
             lm_client: Arc::new(lm),
             app_config: config,
+            available_tools: vec![],
         });
         let app = Router::new()
             .route("/v1/msg", post(msg_handler))

--- a/backend/src/api/routes/sessions.rs
+++ b/backend/src/api/routes/sessions.rs
@@ -89,6 +89,7 @@ mod tests {
             db: Arc::new(db),
             lm_client: Arc::new(MockLmStudioClient::new()),
             app_config: make_config(),
+            available_tools: vec![],
         });
         let app = Router::new()
             .route("/v1/sessions/{session_id}", get(sessions_handler))
@@ -131,7 +132,14 @@ mod tests {
             .once()
             .returning(|_| {
                 Ok(vec![
-                    sample_log("ses-001", "さのまる", "さのまる", "こんにちは", Role::User, None),
+                    sample_log(
+                        "ses-001",
+                        "さのまる",
+                        "さのまる",
+                        "こんにちは",
+                        Role::User,
+                        None,
+                    ),
                     sample_log(
                         "ses-001",
                         "takochan",

--- a/backend/src/core/config.rs
+++ b/backend/src/core/config.rs
@@ -68,13 +68,13 @@ impl AppConfig {
     }
 
     /// 初回セッション（`current_session == "na"`）か
-    #[must_use] 
+    #[must_use]
     pub fn is_first_session(&self) -> bool {
         self.current_session == "na"
     }
 
     /// キャラクター設定ファイルのパスを返す: `{settings_path}/{name}_{version}.json`
-    #[must_use] 
+    #[must_use]
     pub fn character_settings_file(&self) -> String {
         Path::new(&self.character.settings_path)
             .join(format!(
@@ -86,7 +86,7 @@ impl AppConfig {
     }
 
     /// キャラクタープロンプトファイルのパスを返す: `{settings_path}/{name}_{version}.md`
-    #[must_use] 
+    #[must_use]
     pub fn character_prompt_file(&self) -> String {
         Path::new(&self.character.settings_path)
             .join(format!(

--- a/backend/src/core/db.rs
+++ b/backend/src/core/db.rs
@@ -2,7 +2,10 @@ use async_trait::async_trait;
 use chrono::Utc;
 use sqlx::{Row, SqlitePool};
 
-use crate::core::{error::AppError, models::{Role, SessionLog}};
+use crate::core::{
+    error::AppError,
+    models::{Role, SessionLog},
+};
 
 /// 会話ログ永続化のトレイト（モック・スタブ差し替え可能）
 #[cfg_attr(test, mockall::automock)]
@@ -17,7 +20,7 @@ pub struct SqliteConversationRepository {
 }
 
 impl SqliteConversationRepository {
-    #[must_use] 
+    #[must_use]
     pub fn new(pool: SqlitePool) -> Self {
         Self { pool }
     }
@@ -97,7 +100,7 @@ impl ConversationRepository for SqliteConversationRepository {
                     total_output_tokens: r.get("total_output_tokens"),
                     timestamp,
                     role,
-                    emotion:             r.get("emotion"),
+                    emotion: r.get("emotion"),
                 })
             })
             .collect()

--- a/backend/src/core/error.rs
+++ b/backend/src/core/error.rs
@@ -21,6 +21,9 @@ pub enum AppError {
 
     #[error("Validation error: {0}")]
     Validation(String),
+
+    #[error("MCP error: {0}")]
+    Mcp(String),
 }
 
 impl IntoResponse for AppError {
@@ -31,6 +34,7 @@ impl IntoResponse for AppError {
             AppError::Config(_) => (StatusCode::INTERNAL_SERVER_ERROR, "CONFIG_ERROR"),
             AppError::HttpRequest(_) => (StatusCode::BAD_GATEWAY, "HTTP_REQUEST_ERROR"),
             AppError::Validation(_) => (StatusCode::BAD_REQUEST, "VALIDATION_ERROR"),
+            AppError::Mcp(_) => (StatusCode::INTERNAL_SERVER_ERROR, "MCP_ERROR"),
         };
         let message = self.to_string();
         (
@@ -85,5 +89,13 @@ mod tests {
     fn error_display_contains_message() {
         let err = AppError::LmStudio("接続失敗".into());
         assert!(err.to_string().contains("接続失敗"));
+    }
+
+    #[test]
+    fn mcp_error_returns_500() {
+        assert_eq!(
+            status_of(AppError::Mcp("uv not found".into())),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
     }
 }

--- a/backend/src/core/mcp.rs
+++ b/backend/src/core/mcp.rs
@@ -1,0 +1,91 @@
+use async_trait::async_trait;
+use tokio::process::Command;
+
+use crate::core::error::AppError;
+
+// ───────────────────────────────────── Trait ───────────────────────────────
+
+/// MCPツールリストの取得トレイト（テスト時はモックに差し替え可）
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait McpToolProvider: Send + Sync {
+    async fn list_tools(&self) -> Result<Vec<String>, AppError>;
+}
+
+// ───────────────────────────────────── 実装 ────────────────────────────────
+
+/// `uv tool list` の出力から MCPツール名を収集する実装
+pub struct UvMcpToolProvider;
+
+#[async_trait]
+impl McpToolProvider for UvMcpToolProvider {
+    async fn list_tools(&self) -> Result<Vec<String>, AppError> {
+        let output = Command::new("uv")
+            .args(["tool", "list"])
+            .output()
+            .await
+            .map_err(|e| AppError::Mcp(format!("uv tool list failed: {e}")))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(AppError::Mcp(format!(
+                "uv tool list exited with error: {stderr}"
+            )));
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        Ok(parse_uv_tool_list(&stdout))
+    }
+}
+
+/// `uv tool list` のstdoutをパースして `- ` で始まる行のツール名リストを返す
+#[must_use]
+pub fn parse_uv_tool_list(output: &str) -> Vec<String> {
+    output
+        .lines()
+        .filter_map(|line| line.strip_prefix("- "))
+        .map(|name| name.trim().to_string())
+        .filter(|name| !name.is_empty())
+        .collect()
+}
+
+// ───────────────────────────────────── テスト ──────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_uv_tool_list_extracts_tool_names() {
+        let output = "takochan 1.0.0\n- takochan\n- takochan-mcp\nnekobox 0.1.0\n- nekobox\n";
+        let tools = parse_uv_tool_list(output);
+        assert_eq!(tools, vec!["takochan", "takochan-mcp", "nekobox"]);
+    }
+
+    #[test]
+    fn parse_uv_tool_list_empty_output_returns_empty() {
+        let tools = parse_uv_tool_list("");
+        assert!(tools.is_empty());
+    }
+
+    #[test]
+    fn parse_uv_tool_list_no_dash_lines_returns_empty() {
+        let output = "takochan 1.0.0\nnekobox 0.1.0\n";
+        let tools = parse_uv_tool_list(output);
+        assert!(tools.is_empty());
+    }
+
+    #[test]
+    fn parse_uv_tool_list_ignores_empty_after_prefix() {
+        let output = "- \n- valid-tool\n";
+        let tools = parse_uv_tool_list(output);
+        assert_eq!(tools, vec!["valid-tool"]);
+    }
+
+    #[test]
+    fn parse_uv_tool_list_trims_whitespace() {
+        let output = "-   spaced-tool  \n";
+        let tools = parse_uv_tool_list(output);
+        assert_eq!(tools, vec!["spaced-tool"]);
+    }
+}

--- a/backend/src/core/mod.rs
+++ b/backend/src/core/mod.rs
@@ -1,4 +1,5 @@
 pub mod config;
 pub mod db;
 pub mod error;
+pub mod mcp;
 pub mod models;

--- a/backend/src/core/models.rs
+++ b/backend/src/core/models.rs
@@ -14,22 +14,22 @@ impl SessionId {
         Ok(Self(id))
     }
 
-    #[must_use] 
+    #[must_use]
     pub fn generate() -> Self {
         Self(uuid::Uuid::new_v4().to_string())
     }
 
-    #[must_use] 
+    #[must_use]
     pub fn initial() -> Self {
         Self("na".into())
     }
 
-    #[must_use] 
+    #[must_use]
     pub fn is_na(&self) -> bool {
         self.0 == "na"
     }
 
-    #[must_use] 
+    #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
     }
@@ -48,7 +48,7 @@ impl UserName {
         Ok(Self(name))
     }
 
-    #[must_use] 
+    #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
     }
@@ -67,7 +67,7 @@ impl CharacterName {
         Ok(Self(name))
     }
 
-    #[must_use] 
+    #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
     }
@@ -86,7 +86,7 @@ impl CharacterVersion {
         Ok(Self(version))
     }
 
-    #[must_use] 
+    #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
     }
@@ -115,7 +115,7 @@ pub enum Emotion {
 }
 
 impl Emotion {
-    #[must_use] 
+    #[must_use]
     pub fn as_str(&self) -> &str {
         match self {
             Self::Fun => "楽しい",
@@ -130,7 +130,7 @@ impl Emotion {
     }
 
     #[allow(clippy::should_implement_trait)]
-    #[must_use] 
+    #[must_use]
     pub fn from_str(s: &str) -> Option<Self> {
         match s {
             "楽しい" => Some(Self::Fun),

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -10,4 +10,6 @@ pub struct AppState {
     pub db: Arc<dyn ConversationRepository>,
     pub lm_client: Arc<dyn LmStudioClient>,
     pub app_config: AppConfig,
+    /// uv tool list から取得した利用可能な MCP ツール名一覧
+    pub available_tools: Vec<String>,
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -15,6 +15,7 @@ use nekobox_backend::{
     core::{
         config::AppConfig,
         db::{ConversationRepository, SqliteConversationRepository},
+        mcp::{McpToolProvider, UvMcpToolProvider},
     },
     AppState,
 };
@@ -48,10 +49,24 @@ async fn main() -> Result<()> {
     let lm_base_url = format!("http://{lm_host}:{lm_port}");
     let lm_client: Arc<dyn LmStudioClient> = Arc::new(HttpLmStudioClient::new(lm_base_url));
 
+    // MCP ツールリスト取得（失敗時は空リストで続行）
+    let mcp_provider = UvMcpToolProvider;
+    let available_tools = match mcp_provider.list_tools().await {
+        Ok(tools) => {
+            info!("MCP tools loaded: {:?}", tools);
+            tools
+        }
+        Err(e) => {
+            tracing::warn!("Failed to load MCP tools, continuing with empty list: {e}");
+            vec![]
+        }
+    };
+
     let state = Arc::new(AppState {
         db,
         lm_client,
         app_config,
+        available_tools,
     });
 
     let app = Router::new()

--- a/backend/tests/integration_test.rs
+++ b/backend/tests/integration_test.rs
@@ -90,6 +90,7 @@ fn make_server(pool: SqlitePool, lm: Arc<dyn LmStudioClient>, config: AppConfig)
         db: Arc::new(SqliteConversationRepository::new(pool)),
         lm_client: lm,
         app_config: config,
+        available_tools: vec![],
     });
     let app = Router::new()
         .route("/v1/msg", post(msg_handler))


### PR DESCRIPTION
## Summary

- `core/mcp.rs` を新規作成。`McpToolProvider` trait と `UvMcpToolProvider` 実装を追加
- `uv tool list` の stdout から `- ` で始まる行をパースしてツール名リストを構築
- `AppState` に `available_tools: Vec<String>` を追加し、起動時にメモリへ保持
- `uv` が利用不可な場合は警告ログを出力して空リストで続行（サーバ起動はブロックしない）
- `AppError` に `Mcp` バリアントを追加

## Test plan

- [x] `parse_uv_tool_list` のユニットテスト 5件（通常出力・空・`- `なし・空名・スペース含む）
- [x] `AppError::Mcp` のステータスコードテスト 1件
- [x] 既存テスト 65件全パス確認
- [x] `cargo clippy -- -W clippy::pedantic` でエラーなし確認
- [x] `cargo fmt --check` でフォーマット差分なし確認

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)