### PR TITLE
feat: MCPツールサポート実装 (#18)

### DIFF
--- a/backend/src/api/lm_studio.rs
+++ b/backend/src/api/lm_studio.rs
@@ -3,6 +3,40 @@ use serde::{Deserialize, Serialize};
 
 use crate::core::error::AppError;
 
+// ───────────────────────────────────── Tool structs ────────────────────────
+
+/// LM Studio へ渡すツール定義（OpenAI function calling 形式）
+#[derive(Debug, Serialize, Clone)]
+pub struct ToolSpec {
+    #[serde(rename = "type")]
+    pub spec_type: String,
+    pub function: FunctionSpec,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct FunctionSpec {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub parameters: serde_json::Value,
+}
+
+/// LM Studio からのレスポンス中のツール呼び出し情報
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ToolCall {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub call_type: String,
+    pub function: ToolCallFunction,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ToolCallFunction {
+    pub name: String,
+    /// JSON 文字列として返されるツール引数
+    pub arguments: String,
+}
+
 // ───────────────────────────────────── Request ─────────────────────────────
 
 #[derive(Debug, Serialize)]
@@ -10,12 +44,26 @@ pub struct ChatRequest {
     pub model: String,
     pub messages: Vec<ChatMessage>,
     pub temperature: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<ToolSpec>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ChatMessage {
     pub role: String,
-    pub content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    /// アシスタントがツールを呼び出す際に設定される
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<ToolCall>>,
+    /// ツール結果メッセージの場合に対応する tool_call の ID を設定する
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+    /// ツール結果メッセージのツール名（任意）
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
 }
 
 // ───────────────────────────────────── Response ────────────────────────────

--- a/backend/src/api/routes/msg.rs
+++ b/backend/src/api/routes/msg.rs
@@ -4,13 +4,17 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::{
-    api::lm_studio::{ChatMessage, ChatRequest},
+    api::lm_studio::{ChatMessage, ChatRequest, FunctionSpec, ToolSpec},
     core::{
         error::AppError,
+        mcp::McpToolDefinition,
         models::{Emotion, Role, SessionLog},
     },
     AppState,
 };
+
+/// ツール呼び出しの最大ループ回数（無限ループ防止）
+const MAX_TOOL_ITERATIONS: usize = 5;
 
 // ───────────────────────────────────── Request / Response ──────────────────
 
@@ -47,6 +51,7 @@ struct LmJsonContent {
 
 // ───────────────────────────────────── ハンドラ ────────────────────────────
 
+#[allow(clippy::too_many_lines)]
 pub async fn msg_handler(
     State(state): State<Arc<AppState>>,
     Json(req): Json<MsgRequest>,
@@ -65,53 +70,47 @@ pub async fn msg_handler(
     // system_prompt をキャラクター設定ファイルからロード
     let system_prompt = state.app_config.load_system_prompt()?;
 
-    // LM Studio へ送るメッセージを構築
-    let messages = vec![
+    // LM Studio へ送る初期メッセージを構築
+    let mut messages = vec![
         ChatMessage {
             role: "system".to_string(),
-            content: system_prompt,
+            content: Some(system_prompt),
+            tool_calls: None,
+            tool_call_id: None,
+            name: None,
         },
         ChatMessage {
             role: "user".to_string(),
-            content: req.message.clone(),
+            content: Some(req.message.clone()),
+            tool_calls: None,
+            tool_call_id: None,
+            name: None,
         },
     ];
 
-    let lm_request = ChatRequest {
+    // 利用可能なツールを OpenAI function calling 形式に変換
+    let tools = build_tool_specs(&state.available_tools);
+    let tool_choice = tools.as_ref().map(|_| "auto".to_string());
+
+    // ── 最初の LM Studio 呼び出し（エラー時は DB に書き込まない）──
+    let first_request = ChatRequest {
         model: state.app_config.character.name.clone(),
-        messages,
+        messages: messages.clone(),
         temperature: state.app_config.model.temperature,
+        tools: tools.clone(),
+        tool_choice: tool_choice.clone(),
     };
+    let mut lm_response = state.lm_client.chat(first_request).await?;
 
-    // LM Studio にリクエスト送信
-    let lm_response = state.lm_client.chat(lm_request).await?;
-
-    let new_response_id = Some(lm_response.id.clone());
-    let model_instance_id = lm_response.model.clone();
-    let (input_tokens, output_tokens) = lm_response
-        .usage
-        .as_ref()
-        .map_or((None, None), |u| (u.prompt_tokens, u.completion_tokens));
-
-    let raw_content = lm_response
-        .choices
-        .first()
-        .map(|c| c.message.content.clone())
-        .unwrap_or_default();
-
-    // LM Studio レスポンスから message と emotion を抽出
-    let (character_message, emotion) = parse_lm_response(&raw_content);
+    // 最初の LM 呼び出し成功後にターン番号を算出し、ユーザーメッセージを保存
     let settings_name = format!("{}_{}", req.character_name, req.version);
     let bg = state
         .app_config
         .background_image
         .clone()
         .unwrap_or_default();
-
-    // 新しいターン番号を算出（現在の最大ターン + 1）
     let turn_number = state.db.get_current_turn(&req.session_id).await? + 1;
 
-    // ユーザーメッセージをDBに保存
     state
         .db
         .save_log(&SessionLog {
@@ -133,6 +132,107 @@ pub async fn msg_handler(
             turn_number,
         })
         .await?;
+
+    // ── ツール呼び出しループ ────────────────────────────────────────────────
+    // ツールループ中は turn_number を変えない（同一ターン内の処理）
+    let (final_resp_id, final_model, final_usage, final_content) = 'tool_loop: {
+        for _iteration in 0..MAX_TOOL_ITERATIONS {
+            let resp_id = lm_response.id.clone();
+            let resp_model = lm_response.model.clone();
+            let resp_usage = lm_response.usage;
+
+            let choice = lm_response.choices.into_iter().next().ok_or_else(|| {
+                AppError::LmStudio("LM Studioのレスポンスにchoicesがありません".into())
+            })?;
+
+            // tool_calls がない、または空の場合は最終レスポンスとして break
+            let has_tool_calls = choice
+                .message
+                .tool_calls
+                .as_ref()
+                .is_some_and(|v| !v.is_empty());
+
+            if !has_tool_calls {
+                break 'tool_loop (resp_id, resp_model, resp_usage, choice.message.content);
+            }
+
+            // ─ ツール呼び出し処理 ─
+            let tool_calls = choice.message.tool_calls.clone().unwrap_or_default();
+
+            // アシスタントのメッセージ（tool_calls 付き）を会話履歴に追加
+            messages.push(choice.message);
+
+            for tc in &tool_calls {
+                let args: serde_json::Value =
+                    serde_json::from_str(&tc.function.arguments).unwrap_or_default();
+
+                let server_cmd = find_server_command(&state.available_tools, &tc.function.name);
+
+                // MCP サーバーを呼び出す（エラーはテキストとして処理を継続）
+                let tool_result = state
+                    .mcp_provider
+                    .call_tool(&server_cmd, &tc.function.name, args)
+                    .await
+                    .unwrap_or_else(|e| format!("ツールエラー: {e}"));
+
+                // ツール結果を DB に保存（同一ターン番号）
+                state
+                    .db
+                    .save_log(&SessionLog {
+                        session_id: req.session_id.clone(),
+                        session_alias: req.session_alias.clone(),
+                        background_image: bg.clone(),
+                        msg_sender_name: tc.function.name.clone(),
+                        user_name: req.user_name.clone(),
+                        settings_name: settings_name.clone(),
+                        msg: tool_result.clone(),
+                        image_url: None,
+                        response_id: None,
+                        model_instance_id: None,
+                        input_tokens: None,
+                        total_output_tokens: None,
+                        timestamp: Utc::now(),
+                        role: Role::Tool,
+                        emotion: None,
+                        turn_number,
+                    })
+                    .await?;
+
+                // ツール結果を会話履歴に追加
+                messages.push(ChatMessage {
+                    role: "tool".to_string(),
+                    content: Some(tool_result),
+                    tool_calls: None,
+                    tool_call_id: Some(tc.id.clone()),
+                    name: Some(tc.function.name.clone()),
+                });
+            }
+
+            // 更新した会話履歴で LM Studio を再度呼び出す
+            let next_request = ChatRequest {
+                model: state.app_config.character.name.clone(),
+                messages: messages.clone(),
+                temperature: state.app_config.model.temperature,
+                tools: tools.clone(),
+                tool_choice: tool_choice.clone(),
+            };
+            lm_response = state.lm_client.chat(next_request).await?;
+        }
+
+        return Err(AppError::LmStudio(
+            "ツールループが最大イテレーション数を超えました".into(),
+        ));
+    };
+
+    let new_response_id = Some(final_resp_id);
+    let model_instance_id = final_model;
+    let (input_tokens, output_tokens) = final_usage
+        .as_ref()
+        .map_or((None, None), |u| (u.prompt_tokens, u.completion_tokens));
+
+    // LM Studio レスポンスから message と emotion を抽出
+    let raw_content = final_content.unwrap_or_default();
+    let (character_message, emotion) = parse_lm_response(&raw_content);
 
     // キャラクターのレスポンスをDBに保存（同じターン番号）
     state
@@ -167,6 +267,36 @@ pub async fn msg_handler(
         message: character_message,
         emotion: emotion.as_str().to_string(),
     }))
+}
+
+// ───────────────────────────────────── ヘルパー ────────────────────────────
+
+/// 利用可能なツール定義を LM Studio 用の ToolSpec リストに変換する
+fn build_tool_specs(tools: &[McpToolDefinition]) -> Option<Vec<ToolSpec>> {
+    if tools.is_empty() {
+        return None;
+    }
+    Some(
+        tools
+            .iter()
+            .map(|t| ToolSpec {
+                spec_type: "function".to_string(),
+                function: FunctionSpec {
+                    name: t.name.clone(),
+                    description: t.description.clone(),
+                    parameters: t.input_schema.clone(),
+                },
+            })
+            .collect(),
+    )
+}
+
+/// ツール名からサーバーコマンドを検索する（見つからなければツール名をそのまま返す）
+fn find_server_command(tools: &[McpToolDefinition], tool_name: &str) -> String {
+    tools
+        .iter()
+        .find(|t| t.name == tool_name)
+        .map_or_else(|| tool_name.to_string(), |t| t.server_command.clone())
 }
 
 /// LM Studio が返す JSON コンテンツをパースして (message, emotion) を返す
@@ -209,6 +339,7 @@ mod tests {
         core::{
             config::{AppConfig, CharacterConfig, ModelConfig},
             db::MockConversationRepository,
+            mcp::MockMcpToolProvider,
         },
         AppState,
     };
@@ -243,7 +374,10 @@ mod tests {
             choices: vec![ChatChoice {
                 message: crate::api::lm_studio::ChatMessage {
                     role: "assistant".to_string(),
-                    content: format!(r#"{{"message":"{msg}","emotion":"{emotion}"}}"#),
+                    content: Some(format!(r#"{{"message":"{msg}","emotion":"{emotion}"}}"#)),
+                    tool_calls: None,
+                    tool_call_id: None,
+                    name: None,
                 },
                 finish_reason: Some("stop".to_string()),
             }],
@@ -262,6 +396,7 @@ mod tests {
             lm_client: Arc::new(lm),
             app_config: config,
             available_tools: vec![],
+            mcp_provider: Arc::new(MockMcpToolProvider::new()),
         });
         let app = Router::new()
             .route("/v1/msg", post(msg_handler))
@@ -474,5 +609,113 @@ mod tests {
             .json(&valid_body())
             .await
             .assert_status(StatusCode::OK);
+    }
+
+    /// ツール呼び出しループ: LMがtool_callsを返し、ツール実行後に最終レスポンスを返すケース
+    #[tokio::test]
+    async fn msg_handler_executes_tool_call_and_returns_final_response() {
+        use crate::api::lm_studio::{ToolCall, ToolCallFunction};
+        use crate::core::mcp::McpToolDefinition;
+
+        // 1回目: tool_calls を返す
+        let tool_call_response = ChatResponse {
+            id: "resp-tool".to_string(),
+            choices: vec![ChatChoice {
+                message: ChatMessage {
+                    role: "assistant".to_string(),
+                    content: None,
+                    tool_calls: Some(vec![ToolCall {
+                        id: "call-001".to_string(),
+                        call_type: "function".to_string(),
+                        function: ToolCallFunction {
+                            name: "weather_get".to_string(),
+                            arguments: r#"{"city":"Tokyo"}"#.to_string(),
+                        },
+                    }]),
+                    tool_call_id: None,
+                    name: None,
+                },
+                finish_reason: Some("tool_calls".to_string()),
+            }],
+            usage: None,
+            model: Some("takochan".to_string()),
+        };
+
+        // 2回目: 最終レスポンス
+        let final_response = lm_response("東京は晴れです！", "嬉しい");
+
+        let mut lm = MockLmStudioClient::new();
+        let mut call_count = 0usize;
+        lm.expect_chat().times(2).returning(move |_| {
+            call_count += 1;
+            if call_count == 1 {
+                Ok(ChatResponse {
+                    id: "resp-tool".to_string(),
+                    choices: vec![ChatChoice {
+                        message: ChatMessage {
+                            role: "assistant".to_string(),
+                            content: None,
+                            tool_calls: Some(vec![ToolCall {
+                                id: "call-001".to_string(),
+                                call_type: "function".to_string(),
+                                function: ToolCallFunction {
+                                    name: "weather_get".to_string(),
+                                    arguments: r#"{"city":"Tokyo"}"#.to_string(),
+                                },
+                            }]),
+                            tool_call_id: None,
+                            name: None,
+                        },
+                        finish_reason: Some("tool_calls".to_string()),
+                    }],
+                    usage: None,
+                    model: Some("takochan".to_string()),
+                })
+            } else {
+                Ok(lm_response("東京は晴れです！", "嬉しい"))
+            }
+        });
+
+        let mut db = MockConversationRepository::new();
+        db.expect_get_current_turn().once().returning(|_| Ok(0));
+        // user(1) + tool(1) + assistant(1) = 3回 save_log が呼ばれる
+        db.expect_save_log()
+            .times(3)
+            .withf(|log| log.turn_number == 1)
+            .returning(|_| Ok(()));
+
+        let mut mcp = MockMcpToolProvider::new();
+        mcp.expect_call_tool()
+            .once()
+            .returning(|_, _, _| Ok("東京の天気: 晴れ, 25℃".to_string()));
+
+        let (cfg, _tmp) = make_config();
+        let tool_def = McpToolDefinition {
+            name: "weather_get".to_string(),
+            description: Some("天気を取得する".to_string()),
+            input_schema: serde_json::json!({}),
+            server_command: "weather-mcp".to_string(),
+        };
+        let state = Arc::new(AppState {
+            db: Arc::new(db),
+            lm_client: Arc::new(lm),
+            app_config: cfg,
+            available_tools: vec![tool_def],
+            mcp_provider: Arc::new(mcp),
+        });
+
+        let _ = tool_call_response; // suppress unused warning
+        let _ = final_response;
+
+        let app = Router::new()
+            .route("/v1/msg", post(msg_handler))
+            .with_state(state);
+        let server = TestServer::new(app);
+
+        let res = server.post("/v1/msg").json(&valid_body()).await;
+        res.assert_status(StatusCode::OK);
+        let json = res.json::<serde_json::Value>();
+        assert_eq!(json["message"], "東京は晴れです！");
+        assert_eq!(json["emotion"], "嬉しい");
     }
 }

--- a/backend/src/api/routes/sessions.rs
+++ b/backend/src/api/routes/sessions.rs
@@ -92,6 +92,7 @@ mod tests {
             lm_client: Arc::new(MockLmStudioClient::new()),
             app_config: make_config(),
             available_tools: vec![],
+            mcp_provider: Arc::new(crate::core::mcp::MockMcpToolProvider::new()),
         });
         let app = Router::new()
             .route("/v1/sessions/{session_id}", get(sessions_handler))

--- a/backend/src/core/mcp.rs
+++ b/backend/src/core/mcp.rs
@@ -1,42 +1,285 @@
 use async_trait::async_trait;
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::process::Stdio;
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::process::Command;
+use tokio::time;
 
 use crate::core::error::AppError;
 
+/// MCP セッションのタイムアウト秒数
+const MCP_TIMEOUT_SECS: u64 = 5;
+
+// ───────────────────────────────────── 型 ──────────────────────────────────
+
+/// MCP サーバーから取得したツール定義
+#[derive(Debug, Clone)]
+pub struct McpToolDefinition {
+    /// ツール名（例: `weather_get`）
+    pub name: String,
+    /// ツールの説明
+    pub description: Option<String>,
+    /// JSON Schema 形式の入力スキーマ
+    pub input_schema: Value,
+    /// このツールを提供するサーバーコマンド（uv tool run に渡すパッケージ名）
+    pub server_command: String,
+}
+
 // ───────────────────────────────────── Trait ───────────────────────────────
 
-/// MCPツールリストの取得トレイト（テスト時はモックに差し替え可）
+/// MCPツール操作のトレイト（テスト時はモックに差し替え可）
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait McpToolProvider: Send + Sync {
-    async fn list_tools(&self) -> Result<Vec<String>, AppError>;
+    /// MCP サーバーを起動してツール定義一覧を取得する
+    async fn list_tools(&self, server_command: &str) -> Result<Vec<McpToolDefinition>, AppError>;
+
+    /// MCP サーバーを起動してツールを呼び出し、テキスト結果を返す
+    async fn call_tool(
+        &self,
+        server_command: &str,
+        tool_name: &str,
+        arguments: Value,
+    ) -> Result<String, AppError>;
 }
 
 // ───────────────────────────────────── 実装 ────────────────────────────────
 
-/// `uv tool list` の出力から MCPツール名を収集する実装
+/// `uv tool run <server_command>` で MCP サーバーを起動する実装
 pub struct UvMcpToolProvider;
 
 #[async_trait]
 impl McpToolProvider for UvMcpToolProvider {
-    async fn list_tools(&self) -> Result<Vec<String>, AppError> {
-        let output = Command::new("uv")
-            .args(["tool", "list"])
-            .output()
-            .await
-            .map_err(|e| AppError::Mcp(format!("uv tool list failed: {e}")))?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(AppError::Mcp(format!(
-                "uv tool list exited with error: {stderr}"
-            )));
+    async fn list_tools(&self, server_command: &str) -> Result<Vec<McpToolDefinition>, AppError> {
+        #[derive(Deserialize)]
+        struct ToolsListResult {
+            tools: Vec<McpToolRaw>,
+        }
+        #[derive(Deserialize)]
+        struct McpToolRaw {
+            name: String,
+            description: Option<String>,
+            #[serde(rename = "inputSchema", default)]
+            input_schema: Value,
         }
 
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        Ok(parse_uv_tool_list(&stdout))
+        let result = mcp_communicate(server_command, "tools/list", None, 2).await?;
+
+        let parsed: ToolsListResult = serde_json::from_value(result)
+            .map_err(|e| AppError::Mcp(format!("tools/list parse error: {e}")))?;
+
+        Ok(parsed
+            .tools
+            .into_iter()
+            .map(|t| McpToolDefinition {
+                name: t.name,
+                description: t.description,
+                input_schema: t.input_schema,
+                server_command: server_command.to_string(),
+            })
+            .collect())
+    }
+
+    async fn call_tool(
+        &self,
+        server_command: &str,
+        tool_name: &str,
+        arguments: Value,
+    ) -> Result<String, AppError> {
+        #[derive(Deserialize)]
+        struct CallResult {
+            content: Vec<McpContent>,
+        }
+        #[derive(Deserialize)]
+        struct McpContent {
+            #[serde(rename = "type")]
+            content_type: String,
+            #[serde(default)]
+            text: String,
+        }
+
+        let result = mcp_communicate(
+            server_command,
+            "tools/call",
+            Some(json!({ "name": tool_name, "arguments": arguments })),
+            2,
+        )
+        .await?;
+
+        let parsed: CallResult = serde_json::from_value(result)
+            .map_err(|e| AppError::Mcp(format!("tools/call parse error: {e}")))?;
+
+        let text = parsed
+            .content
+            .into_iter()
+            .filter(|c| c.content_type == "text")
+            .map(|c| c.text)
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        Ok(text)
     }
 }
+
+// ───────────────────────────────────── MCP JSON-RPC ────────────────────────
+
+/// MCP サーバーを spawn して JSON-RPC セッションを実行する
+async fn mcp_communicate(
+    server_command: &str,
+    method: &str,
+    params: Option<Value>,
+    request_id: u64,
+) -> Result<Value, AppError> {
+    let mut child = Command::new("uv")
+        .args(["tool", "run", server_command])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| AppError::Mcp(format!("cannot spawn {server_command}: {e}")))?;
+
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| AppError::Mcp("stdin unavailable".into()))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| AppError::Mcp("stdout unavailable".into()))?;
+
+    let outcome = time::timeout(
+        Duration::from_secs(MCP_TIMEOUT_SECS),
+        do_mcp_exchange(&mut stdin, stdout, method, params, request_id),
+    )
+    .await
+    .map_err(|_| {
+        AppError::Mcp(format!(
+            "MCP timeout after {MCP_TIMEOUT_SECS}s for {server_command}"
+        ))
+    });
+
+    let _ = child.kill().await;
+
+    match outcome {
+        Err(e) => Err(e),
+        Ok(inner) => inner,
+    }
+}
+
+/// MCP プロトコルの実際の I/O を担う非同期関数
+/// stdin/stdout をジェネリック型にすることでテスト時にメモリ上のパイプを注入できる
+async fn do_mcp_exchange<W, R>(
+    stdin: &mut W,
+    stdout: R,
+    method: &str,
+    params: Option<Value>,
+    request_id: u64,
+) -> Result<Value, AppError>
+where
+    W: AsyncWrite + Unpin,
+    R: AsyncRead + Unpin,
+{
+    let mut reader = BufReader::new(stdout);
+
+    // 1. initialize リクエスト送信
+    write_jsonrpc(
+        stdin,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "nekobox", "version": "0.1.0"}
+            }
+        }),
+    )
+    .await?;
+
+    // 2. initialize レスポンス受信（id=1）
+    read_jsonrpc_response(&mut reader, 1).await?;
+
+    // 3. notifications/initialized 送信（通知なのでIDなし）
+    write_jsonrpc(
+        stdin,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized"
+        }),
+    )
+    .await?;
+
+    // 4. 実際のリクエスト送信
+    let request = if let Some(p) = params {
+        json!({ "jsonrpc": "2.0", "id": request_id, "method": method, "params": p })
+    } else {
+        json!({ "jsonrpc": "2.0", "id": request_id, "method": method })
+    };
+    write_jsonrpc(stdin, request).await?;
+
+    // 5. 実際のレスポンス受信
+    read_jsonrpc_response(&mut reader, request_id).await
+}
+
+/// JSON-RPC メッセージを stdin に改行区切りで書き込む
+async fn write_jsonrpc<W: AsyncWrite + Unpin>(stdin: &mut W, msg: Value) -> Result<(), AppError> {
+    let s =
+        serde_json::to_string(&msg).map_err(|e| AppError::Mcp(format!("serialize error: {e}")))?;
+    stdin
+        .write_all(s.as_bytes())
+        .await
+        .map_err(|e| AppError::Mcp(format!("stdin write error: {e}")))?;
+    stdin
+        .write_all(b"\n")
+        .await
+        .map_err(|e| AppError::Mcp(format!("stdin newline write error: {e}")))?;
+    Ok(())
+}
+
+/// 期待する id のレスポンスを stdout から読み取る（通知行はスキップ）
+async fn read_jsonrpc_response<R: AsyncRead + Unpin>(
+    reader: &mut BufReader<R>,
+    expected_id: u64,
+) -> Result<Value, AppError> {
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let n = reader
+            .read_line(&mut line)
+            .await
+            .map_err(|e| AppError::Mcp(format!("stdout read error: {e}")))?;
+        if n == 0 {
+            return Err(AppError::Mcp(
+                "MCP server closed stdout unexpectedly".into(),
+            ));
+        }
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let resp: Value = serde_json::from_str(trimmed)
+            .map_err(|e| AppError::Mcp(format!("JSON parse error ({e}): {trimmed}")))?;
+
+        // RPC エラーチェック
+        if let Some(err) = resp.get("error") {
+            return Err(AppError::Mcp(format!("MCP RPC error: {err}")));
+        }
+
+        // 期待する id のレスポンスか確認
+        if resp.get("id").and_then(serde_json::Value::as_u64) == Some(expected_id) {
+            return resp
+                .get("result")
+                .cloned()
+                .ok_or_else(|| AppError::Mcp("MCP response missing 'result' field".into()));
+        }
+        // 通知など id が異なるメッセージはスキップ
+    }
+}
+
+// ───────────────────────────────────── ヘルパー ────────────────────────────
 
 /// `uv tool list` のstdoutをパースして `- ` で始まる行のツール名リストを返す
 #[must_use]
@@ -54,6 +297,8 @@ pub fn parse_uv_tool_list(output: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── parse_uv_tool_list ────────────────────────────────────
 
     #[test]
     fn parse_uv_tool_list_extracts_tool_names() {
@@ -87,5 +332,211 @@ mod tests {
         let output = "-   spaced-tool  \n";
         let tools = parse_uv_tool_list(output);
         assert_eq!(tools, vec!["spaced-tool"]);
+    }
+
+    // ── フェイク MCP サーバーヘルパー ─────────────────────────
+
+    /// フェイクの MCP サーバーとして `do_mcp_exchange` に渡す stdin/stdout を構築し、
+    /// サーバー側の応答を別タスクで書き込む。
+    ///
+    /// `server_responses` には、サーバーが送信する改行区切り JSON-RPC メッセージの
+    /// リストを渡す（initialize レスポンス → 実際のメソッドのレスポンス の順）。
+    async fn fake_mcp_exchange(
+        method: &str,
+        params: Option<Value>,
+        request_id: u64,
+        server_responses: Vec<&'static str>,
+    ) -> Result<Value, AppError> {
+        // 全サーバーレスポンスを事前に連結してインメモリバッファを作成する
+        let server_data: Vec<u8> = server_responses
+            .iter()
+            .flat_map(|r| r.as_bytes().iter().copied())
+            .collect();
+
+        // stdin: クライアントの書き込みはすべて破棄（sink）
+        let mut fake_stdin = tokio::io::sink();
+        // stdout: 事前に用意したサーバーデータを返す（Cursor が EOF まで読める）
+        let fake_stdout = std::io::Cursor::new(server_data);
+
+        do_mcp_exchange(&mut fake_stdin, fake_stdout, method, params, request_id).await
+    }
+
+    // ── do_mcp_exchange の正常系テスト ───────────────────────
+
+    #[tokio::test]
+    async fn exchange_list_tools_returns_result() {
+        let init_resp = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{}}}\n";
+        let tools_resp = "{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[{\"name\":\"test_tool\",\"inputSchema\":{}}]}}\n";
+
+        let result = fake_mcp_exchange("tools/list", None, 2, vec![init_resp, tools_resp])
+            .await
+            .unwrap();
+
+        assert_eq!(result["tools"][0]["name"], "test_tool");
+    }
+
+    #[tokio::test]
+    async fn exchange_call_tool_returns_result() {
+        let init_resp = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"capabilities\":{}}}\n";
+        let call_resp = "{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"Tokyo: sunny\"}]}}\n";
+
+        let result = fake_mcp_exchange(
+            "tools/call",
+            Some(json!({"name":"weather","arguments":{}})),
+            2,
+            vec![init_resp, call_resp],
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result["content"][0]["text"], "Tokyo: sunny");
+    }
+
+    #[tokio::test]
+    async fn exchange_skips_notifications_and_finds_correct_id() {
+        // サーバーが id=9 の通知を挟んでも id=2 のレスポンスを正しく取得できる
+        let init_resp = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n";
+        let notif = "{\"jsonrpc\":\"2.0\",\"method\":\"some/notification\",\"params\":{}}\n";
+        let actual_resp = "{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"value\":\"found\"}}\n";
+
+        let result = fake_mcp_exchange("tools/list", None, 2, vec![init_resp, notif, actual_resp])
+            .await
+            .unwrap();
+
+        assert_eq!(result["value"], "found");
+    }
+
+    #[tokio::test]
+    async fn exchange_returns_error_on_rpc_error_response() {
+        let init_resp = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n";
+        let err_resp = "{\"jsonrpc\":\"2.0\",\"id\":2,\"error\":{\"code\":-32601,\"message\":\"Method not found\"}}\n";
+
+        let err = fake_mcp_exchange("tools/list", None, 2, vec![init_resp, err_resp])
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, AppError::Mcp(_)));
+        assert!(err.to_string().contains("MCP RPC error"));
+    }
+
+    #[tokio::test]
+    async fn exchange_returns_error_on_unexpected_eof() {
+        // サーバーが initialize レスポンスだけ返して切断する
+        let init_resp = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n";
+
+        let err = fake_mcp_exchange("tools/list", None, 2, vec![init_resp])
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, AppError::Mcp(_)));
+    }
+
+    #[tokio::test]
+    async fn exchange_returns_error_on_invalid_json() {
+        let init_resp = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n";
+        let bad_json = "not valid json at all\n";
+
+        let err = fake_mcp_exchange("tools/list", None, 2, vec![init_resp, bad_json])
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, AppError::Mcp(_)));
+        assert!(err.to_string().contains("JSON parse error"));
+    }
+
+    #[tokio::test]
+    async fn exchange_returns_error_when_result_missing() {
+        let init_resp = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n";
+        // result フィールドがない
+        let no_result = "{\"jsonrpc\":\"2.0\",\"id\":2}\n";
+
+        let err = fake_mcp_exchange("tools/list", None, 2, vec![init_resp, no_result])
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, AppError::Mcp(_)));
+        assert!(err.to_string().contains("missing 'result'"));
+    }
+
+    // ── write_jsonrpc ─────────────────────────────────────────
+
+    #[tokio::test]
+    async fn write_jsonrpc_appends_newline() {
+        let mut buf = Vec::new();
+        write_jsonrpc(&mut buf, json!({"key": "value"}))
+            .await
+            .unwrap();
+        assert!(buf.ends_with(b"\n"));
+        let s = std::str::from_utf8(&buf).unwrap().trim();
+        let parsed: Value = serde_json::from_str(s).unwrap();
+        assert_eq!(parsed["key"], "value");
+    }
+
+    // ── UvMcpToolProvider parse helpers ───────────────────────
+
+    #[tokio::test]
+    async fn list_tools_parses_valid_response() {
+        // list_tools は内部で mcp_communicate を使うため、
+        // 結果値のパーシングロジックだけを直接テストする
+
+        let raw = json!({
+            "tools": [
+                {"name": "tool_a", "description": "desc a", "inputSchema": {"type": "object"}},
+                {"name": "tool_b", "inputSchema": {}}
+            ]
+        });
+
+        // パーシングのみを検証（subprocess を起動しない）
+        #[derive(Deserialize)]
+        struct ToolsListResult {
+            tools: Vec<McpToolRaw>,
+        }
+        #[derive(Deserialize)]
+        struct McpToolRaw {
+            name: String,
+            description: Option<String>,
+            #[serde(rename = "inputSchema", default)]
+            input_schema: Value,
+        }
+
+        let parsed: ToolsListResult = serde_json::from_value(raw).unwrap();
+        assert_eq!(parsed.tools.len(), 2);
+        assert_eq!(parsed.tools[0].name, "tool_a");
+        assert_eq!(parsed.tools[0].description.as_deref(), Some("desc a"));
+        assert!(parsed.tools[1].description.is_none());
+    }
+
+    #[tokio::test]
+    async fn call_tool_parses_text_content() {
+        let raw = json!({
+            "content": [
+                {"type": "text", "text": "hello"},
+                {"type": "image", "text": "should be ignored"},
+                {"type": "text", "text": "world"}
+            ]
+        });
+
+        #[derive(Deserialize)]
+        struct CallResult {
+            content: Vec<McpContent>,
+        }
+        #[derive(Deserialize)]
+        struct McpContent {
+            #[serde(rename = "type")]
+            content_type: String,
+            #[serde(default)]
+            text: String,
+        }
+
+        let parsed: CallResult = serde_json::from_value(raw).unwrap();
+        let text = parsed
+            .content
+            .into_iter()
+            .filter(|c| c.content_type == "text")
+            .map(|c| c.text)
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert_eq!(text, "hello\nworld");
     }
 }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -4,12 +4,18 @@ pub mod core;
 use std::sync::Arc;
 
 use api::lm_studio::LmStudioClient;
-use core::{config::AppConfig, db::ConversationRepository};
+use core::{
+    config::AppConfig,
+    db::ConversationRepository,
+    mcp::{McpToolDefinition, McpToolProvider},
+};
 
 pub struct AppState {
     pub db: Arc<dyn ConversationRepository>,
     pub lm_client: Arc<dyn LmStudioClient>,
     pub app_config: AppConfig,
-    /// uv tool list から取得した利用可能な MCP ツール名一覧
-    pub available_tools: Vec<String>,
+    /// MCP サーバーから取得した利用可能なツール定義一覧
+    pub available_tools: Vec<McpToolDefinition>,
+    /// MCP ツールの呼び出しプロバイダー
+    pub mcp_provider: Arc<dyn McpToolProvider>,
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -15,7 +15,7 @@ use nekobox_backend::{
     core::{
         config::AppConfig,
         db::{ConversationRepository, SqliteConversationRepository},
-        mcp::{McpToolProvider, UvMcpToolProvider},
+        mcp::{parse_uv_tool_list, McpToolProvider, UvMcpToolProvider},
     },
     AppState,
 };
@@ -49,24 +49,19 @@ async fn main() -> Result<()> {
     let lm_base_url = format!("http://{lm_host}:{lm_port}");
     let lm_client: Arc<dyn LmStudioClient> = Arc::new(HttpLmStudioClient::new(lm_base_url));
 
-    // MCP ツールリスト取得（失敗時は空リストで続行）
-    let mcp_provider = UvMcpToolProvider;
-    let available_tools = match mcp_provider.list_tools().await {
-        Ok(tools) => {
-            info!("MCP tools loaded: {:?}", tools);
-            tools
-        }
-        Err(e) => {
-            tracing::warn!("Failed to load MCP tools, continuing with empty list: {e}");
-            vec![]
-        }
-    };
+    // MCP プロバイダー初期化
+    let mcp_provider: Arc<dyn McpToolProvider> = Arc::new(UvMcpToolProvider);
+
+    // uv tool list でサーバー名を取得し、各サーバーのツール定義を収集
+    let available_tools = collect_mcp_tools(&mcp_provider).await;
+    info!("MCP tools loaded: {} tools total", available_tools.len());
 
     let state = Arc::new(AppState {
         db,
         lm_client,
         app_config,
         available_tools,
+        mcp_provider,
     });
 
     let app = Router::new()
@@ -86,4 +81,45 @@ async fn main() -> Result<()> {
     axum::serve(listener, app).await?;
 
     Ok(())
+}
+
+/// `uv tool list` で MCP サーバー名を取得し、各サーバーのツール定義を収集する
+async fn collect_mcp_tools(
+    provider: &Arc<dyn McpToolProvider>,
+) -> Vec<nekobox_backend::core::mcp::McpToolDefinition> {
+    // uv tool list を実行してサーバー名一覧を取得
+    let server_names = match tokio::process::Command::new("uv")
+        .args(["tool", "list"])
+        .output()
+        .await
+    {
+        Ok(output) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+            parse_uv_tool_list(&stdout)
+        }
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            tracing::warn!("uv tool list failed: {stderr}");
+            return vec![];
+        }
+        Err(e) => {
+            tracing::warn!("Failed to run uv tool list: {e}");
+            return vec![];
+        }
+    };
+
+    // 各サーバーからツール定義を取得
+    let mut all_tools = Vec::new();
+    for name in &server_names {
+        match provider.list_tools(name).await {
+            Ok(tools) => {
+                info!("Loaded {} tool(s) from MCP server '{name}'", tools.len());
+                all_tools.extend(tools);
+            }
+            Err(e) => {
+                tracing::warn!("Failed to load tools from MCP server '{name}': {e}");
+            }
+        }
+    }
+    all_tools
 }

--- a/backend/tests/integration_test.rs
+++ b/backend/tests/integration_test.rs
@@ -5,6 +5,7 @@
 use async_trait::async_trait;
 use axum::{http::StatusCode, routing::post, Router};
 use axum_test::TestServer;
+use serde_json::Value;
 use sqlx::SqlitePool;
 use std::sync::Arc;
 
@@ -17,6 +18,7 @@ use nekobox_backend::{
         config::{AppConfig, CharacterConfig, ModelConfig},
         db::SqliteConversationRepository,
         error::AppError,
+        mcp::{McpToolDefinition, McpToolProvider},
     },
     AppState,
 };
@@ -37,10 +39,13 @@ impl LmStudioClient for SuccessLmClient {
             choices: vec![ChatChoice {
                 message: ChatMessage {
                     role: "assistant".to_string(),
-                    content: format!(
+                    content: Some(format!(
                         r#"{{"message":"{}","emotion":"{}"}}"#,
                         self.message, self.emotion
-                    ),
+                    )),
+                    tool_calls: None,
+                    tool_call_id: None,
+                    name: None,
                 },
                 finish_reason: Some("stop".to_string()),
             }],
@@ -57,6 +62,27 @@ struct ErrorLmClient(String);
 impl LmStudioClient for ErrorLmClient {
     async fn chat(&self, _req: ChatRequest) -> Result<ChatResponse, AppError> {
         Err(AppError::LmStudio(self.0.clone()))
+    }
+}
+
+// ─── McpToolProvider スタブ ───────────────────────────────────────────────
+
+/// ツールを持たない（呼ばれないはず）McpToolProvider スタブ
+struct NoOpMcpProvider;
+
+#[async_trait]
+impl McpToolProvider for NoOpMcpProvider {
+    async fn list_tools(&self, _server_command: &str) -> Result<Vec<McpToolDefinition>, AppError> {
+        Ok(vec![])
+    }
+
+    async fn call_tool(
+        &self,
+        _server_command: &str,
+        _tool_name: &str,
+        _arguments: Value,
+    ) -> Result<String, AppError> {
+        unreachable!("NoOpMcpProvider.call_tool は呼ばれないはず")
     }
 }
 
@@ -91,6 +117,7 @@ fn make_server(pool: SqlitePool, lm: Arc<dyn LmStudioClient>, config: AppConfig)
         lm_client: lm,
         app_config: config,
         available_tools: vec![],
+        mcp_provider: Arc::new(NoOpMcpProvider),
     });
     let app = Router::new()
         .route("/v1/msg", post(msg_handler))


### PR DESCRIPTION
## Summary

- **MCP stdio JSON-RPCクライアント実装**: `initialize` → `tools/list` / `tools/call` のプロトコルを実装
- **ツール定義の自動取得 (Case C)**: 起動時に `uv tool list` → 各MCPサーバーから `McpToolDefinition` を収集
- **LM Studio ツール呼び出しループ**: `MAX_TOOL_ITERATIONS=5` のツール実行ループを実装し、ツール結果を会話履歴に追加して再度LMを呼び出す
- **ターン番号は変化しない**: ツール実行中は同一の `turn_number` を使用（同一ターン内の処理）

## 変更ファイル

- `lm_studio.rs`: `ChatMessage.content` を `Option<String>` に変更、`ToolSpec`/`ToolCall` 等の構造体を追加
- `mcp.rs`: `McpToolDefinition`、`McpToolProvider` トレイト更新、MCP JSON-RPC実装をジェネリック型で設計
- `lib.rs`: `AppState` に `mcp_provider` フィールドと `Vec<McpToolDefinition>` を追加
- `main.rs`: 起動時のMCPツール定義収集ロジック
- `msg.rs`: ツール呼び出しループ実装

## Test plan

- [x] `cargo test` — 79ユニットテスト + 5統合テスト 全通過
- [x] `cargo clippy -- -W clippy::pedantic` — エラーなし
- [x] `cargo fmt` — フォーマット適用済み
- [x] `cargo llvm-cov` — カバレッジ **90.27%** (ライン) 達成

🤖 Generated with [Claude Code](https://claude.com/claude-code)