### PR TITLE
fix: cargo audit 脆弱性 RUSTSEC-2026-0049 修正

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1777,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

- `rustls-webpki` を `0.103.9` → `0.103.10` にアップグレード
- 脆弱性 [RUSTSEC-2026-0049](https://rustsec.org/advisories/RUSTSEC-2026-0049) (CRLs not considered authoritative by Distribution Point due to faulty matching logic) を修正

## 変更ファイル

- `backend/Cargo.lock` のみ（間接依存のバージョン更新）

## Test plan

- [x] `cargo audit` が 0 vulnerabilities で成功
- [x] `cargo build` が成功

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)