### PR TITLE
feat: background_config.json の blur 属性でブラー強度を設定可能にする

### DIFF
--- a/frontend/src/Scripts/AppConfig.cs
+++ b/frontend/src/Scripts/AppConfig.cs
@@ -214,6 +214,12 @@ public sealed class BackgroundEntry
 
     [JsonPropertyName("location_type")]
     public List<string> LocationType { get; set; } = [];
+
+    /// <summary>
+    /// ブラー強度。未設定の場合は null（シェーダーのデフォルト値 3.0 が適用される）。
+    /// </summary>
+    [JsonPropertyName("blur")]
+    public float? Blur { get; set; }
 }
 
 internal sealed class BackgroundConfigFile

--- a/frontend/src/Scripts/Main.cs
+++ b/frontend/src/Scripts/Main.cs
@@ -196,9 +196,23 @@ public partial class Main : Node
             return;
         }
 
-        GD.Print($"背景ロード完了: {_background.Name} ({imagePath})");
         // TextureRect が stretch_mode=0 (SCALE) で自動的にウィンドウサイズに合わせる
         _backgroundRect.Texture = ImageTexture.CreateFromImage(img);
+
+        // ブラー強度をコンフィグから適用（未設定の場合はデフォルト 3.0）
+        const float DefaultBlurAmount = 3.0f;
+        var blurAmount = _background.Blur ?? DefaultBlurAmount;
+        if (_backgroundRect.Material is ShaderMaterial shaderMaterial)
+            shaderMaterial.SetShaderParameter("blur_amount", blurAmount);
+
+        GD.Print(
+            $"[Background] id={_background.Id}" +
+            $" name={_background.Name}" +
+            $" image={imagePath}" +
+            $" description={_background.Description}" +
+            $" location_type=[{string.Join(", ", _background.LocationType)}]" +
+            $" blur={blurAmount}{(_background.Blur is null ? " (default)" : string.Empty)}"
+        );
     }
 
     private static Error DetectAndLoadImage(Image img, byte[] bytes)


### PR DESCRIPTION
## 概要

Closes #28

背景画像のブラー強度をハードコードから `background_config.json` の `blur` 属性で設定可能にします。

## 変更内容

- `BackgroundEntry` に `float? Blur` プロパティを追加（JSON キー: `"blur"`）
- `blur` 未設定の場合は従来通りデフォルト値 `3.0` を適用
- 起動時にブラー強度を含む背景データをログ出力（デフォルト適用時は `(default)` を付記）

## 使用例

```json
{
  "background": [
    {
      "id": "room01",
      "name": "部屋",
      "image": "${HOME}/images/room.jpg",
      "description": "室内背景",
      "location_type": ["indoor"],
      "blur": 5.0
    }
  ]
}
```

## テスト計画

- [ ] `blur` 指定あり → 指定値がシェーダーに適用されることを確認
- [ ] `blur` 省略 → デフォルト 3.0 が適用され、ログに `(default)` が出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)