### PR TITLE
feat: Windows デスクトップショートカット作成機能を追加 (#37)

### DIFF
--- a/scripts_local/create-shortcut.ps1
+++ b/scripts_local/create-shortcut.ps1
@@ -1,0 +1,64 @@
+# nekobox shortcut creator
+#
+# Usage:
+#   .\create-shortcut.ps1 -InstallDir "C:\tools\bin\nekobox"
+#   .\create-shortcut.ps1 -InstallDir "C:\tools\bin\nekobox" -Desktop
+#
+# Creates nekobox.lnk in $InstallDir.
+# With -Desktop, also copies the shortcut to the current user's Desktop.
+
+param(
+    [Parameter(Mandatory)]
+    [string]$InstallDir,
+
+    [switch]$Desktop
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Write-Ok   { param([string]$Msg) Write-Host "[shortcut] $Msg" -ForegroundColor Green }
+function Write-Warn { param([string]$Msg) Write-Host "[shortcut] $Msg" -ForegroundColor Yellow }
+function Write-Fail { param([string]$Msg) Write-Host "[shortcut] $Msg" -ForegroundColor Red }
+
+$startScript  = Join-Path $InstallDir "start.ps1"
+$iconPath     = Join-Path $InstallDir "app_icon.ico"
+$shortcutPath = Join-Path $InstallDir "nekobox.lnk"
+
+if (-not (Test-Path $startScript)) {
+    Write-Fail "start.ps1 not found: $startScript"
+    Write-Fail "Run install-windows.ps1 first."
+    exit 1
+}
+
+if (-not (Test-Path $iconPath)) {
+    Write-Warn "app_icon.ico not found: $iconPath"
+    Write-Warn "Shortcut will be created without a custom icon."
+    $iconLocation = ""
+} else {
+    $iconLocation = "$iconPath,0"
+}
+
+# ---------------------------------------------------------------------------
+# Create shortcut in install directory
+# ---------------------------------------------------------------------------
+$wsh = New-Object -ComObject WScript.Shell
+$lnk = $wsh.CreateShortcut($shortcutPath)
+$lnk.TargetPath      = "powershell.exe"
+$lnk.Arguments       = "-WindowStyle Hidden -ExecutionPolicy Bypass -File `"$startScript`""
+$lnk.WorkingDirectory = $InstallDir
+$lnk.Description     = "nekobox"
+if ($iconLocation) { $lnk.IconLocation = $iconLocation }
+$lnk.Save()
+
+Write-Ok "Shortcut created: $shortcutPath"
+
+# ---------------------------------------------------------------------------
+# Optionally copy to Desktop
+# ---------------------------------------------------------------------------
+if ($Desktop) {
+    $desktopDir     = [Environment]::GetFolderPath("Desktop")
+    $desktopShortcut = Join-Path $desktopDir "nekobox.lnk"
+    Copy-Item -Force -Path $shortcutPath -Destination $desktopShortcut
+    Write-Ok "Desktop shortcut created: $desktopShortcut"
+}

--- a/scripts_local/install-windows.ps1
+++ b/scripts_local/install-windows.ps1
@@ -1,4 +1,4 @@
-﻿# nekobox Windows install script
+# nekobox Windows install script
 #
 # Usage:
 #   .\install-windows.ps1
@@ -94,6 +94,10 @@ if (-not (Test-Path "$InstallDir\config\mcp_servers.json")) {
 }
 Write-Ok "  config/ copied."
 
+Write-Step "Copying app icon..."
+Copy-Item -Force -Path "$ProjectRoot\img\app_icon.ico" -Destination "$InstallDir\app_icon.ico"
+Write-Ok "  app_icon.ico copied."
+
 Write-Step "Copying backend source (for Docker build)..."
 Copy-Item -Recurse -Force -Path "$ProjectRoot\backend" -Destination $InstallDir
 Write-Ok "  backend/ copied."
@@ -145,6 +149,13 @@ Write-Ok "  start.ps1 deployed (Godot: $GodotExe)."
 Write-Host ""
 
 # ---------------------------------------------------------------------------
+# Create shortcut
+# ---------------------------------------------------------------------------
+Write-Step "Creating nekobox.lnk shortcut..."
+& "$ScriptDir\create-shortcut.ps1" -InstallDir $InstallDir -Desktop
+Write-Host ""
+
+# ---------------------------------------------------------------------------
 # Done
 # ---------------------------------------------------------------------------
 Write-Host "============================================================" -ForegroundColor Green
@@ -156,6 +167,7 @@ Write-Host ""
 Write-Host "  Start       : $InstallDir\start.ps1"
 Write-Host "  Start(debug): $InstallDir\start.ps1 -Debug"
 Write-Host "  Stop        : $InstallDir\stop.ps1"
+Write-Host "  Shortcut    : $InstallDir\nekobox.lnk  (also on Desktop)"
 Write-Host ""
 Write-Host "  Log(stdout) : $InstallDir\logs\backend.log"
 Write-Host "  Log(stderr) : $InstallDir\logs\backend-error.log"


### PR DESCRIPTION
## Summary

- `scripts_local/create-shortcut.ps1` を新規追加
  - `nekobox.lnk` を InstallDir に生成（`app_icon.ico` をショートカットアイコンに使用）
  - `-Desktop` フラグでデスクトップにもショートカットをコピー
- `install-windows.ps1` に以下を追加
  - `img/app_icon.ico` → `$InstallDir\app_icon.ico` のコピーステップ
  - インストール完了後に `create-shortcut.ps1` を呼び出してショートカットを自動生成
  - 完了メッセージにショートカットパスを表示

## Test plan

- [ ] `install-windows.ps1` を実行し、`$InstallDir\nekobox.lnk` が生成されることを確認
- [ ] デスクトップに `nekobox.lnk` が生成されることを確認
- [ ] ショートカットのアイコンが `app_icon.ico` になっていることを確認
- [ ] ショートカットをダブルクリックで `start.ps1` が起動することを確認
- [ ] `create-shortcut.ps1 -InstallDir ... -Desktop` を単体実行して正常動作することを確認

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)