### PR TITLE
feat: nekomcp_timer を MCP サーバとして登録し起動時ログを改善

### DIFF
--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 # nekobox backend entrypoint
 # - Reads /nekobox/config/mcp_servers.json and installs listed MCP server packages via uv
+# - mcp_servers.json format:
+#     { "servers": [ { "name": "<pkg>", "source": "<install-source>" }, ... ] }
+#   "name"   : package name used to check uv tool list
+#   "source" : passed to `uv tool install` (PyPI name or git+https://... URL)
 # - Then starts the backend binary
 
 set -e
@@ -9,14 +13,20 @@ CFG=/nekobox/config/mcp_servers.json
 
 if [ -f "$CFG" ]; then
     echo "[nekobox] Reading MCP server list from $CFG"
-    servers=$(jq -r 'if .servers then .servers[] else empty end' "$CFG" 2>/dev/null || true)
-    for pkg in $servers; do
-        [ -z "$pkg" ] && continue
-        if uv tool list 2>/dev/null | grep -q "^$pkg "; then
-            echo "[nekobox] MCP server already installed: $pkg"
+    server_count=$(jq '.servers | length' "$CFG" 2>/dev/null || echo 0)
+    i=0
+    while [ "$i" -lt "$server_count" ]; do
+        name=$(jq -r ".servers[$i].name" "$CFG")
+        source=$(jq -r ".servers[$i].source // .servers[$i].name" "$CFG")
+        i=$((i + 1))
+
+        [ -z "$name" ] || [ "$name" = "null" ] && continue
+
+        if uv tool list 2>/dev/null | grep -q "^${name} "; then
+            echo "[nekobox] MCP server already installed: $name"
         else
-            echo "[nekobox] Installing MCP server: $pkg"
-            uv tool install "$pkg" || echo "[nekobox] WARNING: Failed to install MCP server: $pkg"
+            echo "[nekobox] Installing MCP server: $name (source: $source)"
+            uv tool install "$source" || echo "[nekobox] WARNING: Failed to install MCP server: $name"
         fi
     done
 else

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -160,12 +160,24 @@ async fn collect_mcp_tools(
         }
     };
 
+    if server_names.is_empty() {
+        info!("MCP servers: (none installed)");
+    } else {
+        info!("MCP servers detected: {}", server_names.join(", "));
+    }
+
     // 各サーバーからツール定義を取得
     let mut all_tools = Vec::new();
     for name in &server_names {
         match provider.list_tools(name).await {
             Ok(tools) => {
-                info!("Loaded {} tool(s) from MCP server '{name}'", tools.len());
+                let tool_names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
+                info!(
+                    "MCP server '{}': {} tool(s) [{}]",
+                    name,
+                    tools.len(),
+                    tool_names.join(", ")
+                );
                 all_tools.extend(tools);
             }
             Err(e) => {

--- a/config/mcp_servers.json
+++ b/config/mcp_servers.json
@@ -1,3 +1,8 @@
 {
-  "servers": []
+  "servers": [
+    {
+      "name": "nekomcp_timer",
+      "source": "git+https://github.com/neko32/nekomcp.git#subdirectory=mcp_servers/timer"
+    }
+  ]
 }

--- a/docs/design.md
+++ b/docs/design.md
@@ -197,6 +197,68 @@ ITtsService
 3. `max_chars` を超えるテキストは先頭から切り詰め（プロンプトインジェクション対策）
 4. TTS が無効 or 日本語音声が未インストールの場合はサイレントにスキップ
 
+## MCP (Model Context Protocol) 連携
+
+### 概要
+
+バックエンドは MCP サーバーをサブプロセス (stdio 方式) として起動し、ツール定義の取得 (`tools/list`) とツール呼び出し (`tools/call`) を JSON-RPC 2.0 over stdio で実行する。
+
+```
+[Rust バックエンド]
+    ↓ uv tool run <server_command>  (サブプロセス spawn)
+[MCP サーバー (Python/FastMCP)]
+    ← JSON-RPC 2.0 over stdin/stdout →
+```
+
+### mcp_servers.json (コンテナ起動時にインストールするサーバー定義)
+
+パス: `$NEKOBOX_CFG_PATH/mcp_servers.json`
+
+```json
+{
+  "servers": [
+    {
+      "name": "nekomcp_timer",
+      "source": "git+https://github.com/neko32/nekomcp.git#subdirectory=mcp_servers/timer"
+    }
+  ]
+}
+```
+
+| フィールド | 説明 |
+|-----------|------|
+| `name`    | パッケージ名。`uv tool list` の出力でインストール済みチェックに使用 |
+| `source`  | `uv tool install` に渡すインストールソース。PyPI 名または `git+https://...` URL |
+
+`entrypoint.sh` がコンテナ起動時に `mcp_servers.json` を読み込み、未インストールのサーバーを `uv tool install <source>` で自動インストールする。インストール済みのサーバーはスキップされる（`uv` のキャッシュボリューム `/nekobox/uv` により永続化）。
+
+### MCP プロトコルフロー
+
+```
+client → server : {"jsonrpc":"2.0","id":1,"method":"initialize","params":{...}}
+server → client : {"jsonrpc":"2.0","id":1,"result":{...}}
+client → server : {"jsonrpc":"2.0","method":"notifications/initialized"}
+client → server : {"jsonrpc":"2.0","id":2,"method":"tools/list"}
+server → client : {"jsonrpc":"2.0","id":2,"result":{"tools":[...]}}
+```
+
+### 現在登録済みの MCP サーバー
+
+| サーバー名 | ツール | 説明 |
+|-----------|--------|------|
+| `nekomcp_timer` | `get_time` | 現在時刻を `HH:MM:SS` 形式で返す |
+| `nekomcp_timer` | `get_date` | 現在日付を `YYYY-MM-DD` 形式で返す |
+
+### Rust 実装
+
+| モジュール | 説明 |
+|-----------|------|
+| `core::mcp::McpToolProvider` | トレイト定義（テスト時は `MockMcpToolProvider` に差し替え） |
+| `core::mcp::UvMcpToolProvider` | `uv tool run` でサブプロセスを spawn する実装 |
+| `core::mcp::parse_uv_tool_list` | `uv tool list` 出力をパースしてコマンド名リストを返す |
+
+バックエンド起動時に `uv tool list` で全インストール済みサーバーを検出し、各サーバーの `tools/list` を呼び出してツール定義を `AppState::available_tools` に格納する。LM Studio へのリクエスト時にこの定義が `tools` パラメータとして渡され、AI がツールを呼び出せるようになる。
+
 ## MVP 以降の拡張予定
 
 - キャラクターの入れ替え機能


### PR DESCRIPTION
## Summary

- `config/mcp_servers.json` を `{ name, source }` オブジェクト形式に変更し、`nekomcp_timer` を `git+https://github.com/neko32/nekomcp.git#subdirectory=mcp_servers/timer` で登録
- `backend/entrypoint.sh` を新スキーマに対応: インデックスループで `name`/`source` を個別取得し、`#` を含む git URL でも単語分割が起きない安全な処理に変更
- `backend/src/main.rs` の起動ログを改善: 検出 MCP サーバー一覧とツール名リストを表示
- `docs/design.md` に MCP 連携アーキテクチャ・設定仕様・登録済みサーバー一覧を追記

## Test plan

- [x] `cargo test` 127 tests 全パス
- [x] コンテナ起動時に `nekomcp_timer` が自動インストールされることを確認
- [x] 起動ログに `MCP servers detected: nekomcp_timer` と `get_time, get_date` が表示されることを確認

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)